### PR TITLE
Parse duration according to the spec

### DIFF
--- a/src/parsers/duration.rs
+++ b/src/parsers/duration.rs
@@ -6,21 +6,21 @@ use std::str;
 use std::str::FromStr;
 
 named!(u32_digit<u32>,
-  map_res!(
     map_res!(
-      digit,
-      str::from_utf8
-    ),
-    FromStr::from_str
-  )
+        map_res!(
+            digit, 
+            str::from_utf8
+        ), 
+        FromStr::from_str
+    )
 );
 
 // parse duration
 named!(pub duration <Duration>, chain!(
     complete!(tag!("P")) ~
-    y: preceded!(tag!("Y"), u32_digit)? ~
-    m: preceded!(tag!("M"), u32_digit)? ~
-    d: preceded!(tag!("D"), u32_digit)? ~
+    y: terminated!(u32_digit, tag!("Y"))? ~
+    m: terminated!(u32_digit, tag!("M"))? ~
+    d: terminated!(u32_digit, tag!("D"))? ~
     dt: duration_time?,
     || {
         let duration_time = match dt {
@@ -39,11 +39,11 @@ named!(pub duration <Duration>, chain!(
 ));
 
 // parse duration time
-named!(duration_time <(u32, u32, u32)>, dbg!(chain!(
+named!(duration_time<(u32, u32, u32)>, dbg!(chain!(
     complete!(tag!("T")) ~
-    h: preceded!(tag!("H"), u32_digit)? ~
-    m: preceded!(tag!("M"), u32_digit)? ~
-    s: preceded!(tag!("S"), u32_digit)?,
+    h: terminated!(u32_digit, tag!("H"))? ~
+    m: terminated!(u32_digit, tag!("M"))? ~
+    s: terminated!(u32_digit, tag!("S"))?,
     || {
         (h.unwrap_or(0), m.unwrap_or(0), s.unwrap_or(0))
     }
@@ -59,88 +59,110 @@ mod tests {
 
     #[test]
     fn test_duration_time() {
-        assert_eq!(Done(&[][..], (10, 10, 10)), duration_time(b"TH10M10S10"));
+        assert_eq!(Done(&[][..], (10, 10, 10)), duration_time(b"T10H10M10S"));
 
-        assert_eq!(Done(&[][..], (10, 10, 0)), duration_time(b"TH10M10S0"));
+        assert_eq!(Done(&[][..], (10, 10, 0)), duration_time(b"T10H10M0S"));
 
-        assert_eq!(Done(&[][..], (10, 0, 0)), duration_time(b"TH10S0"));
+        assert_eq!(Done(&[][..], (10, 0, 0)), duration_time(b"T10H0S"));
 
+        assert_eq!(Done(&[][..], (0, 0, 200)), duration_time(b"T200S"));
 
-        assert_eq!(Done(&[][..], (0, 0, 200)), duration_time(b"TS200"));
-
-        assert!(duration_time(b"H10M10S10").is_err());
-        assert!(duration_time(b"H10S10M10").is_err());
+        assert!(duration_time(b"10H10M10S").is_err());
+        assert!(duration_time(b"10H10S10M").is_err());
     }
 
     #[test]
     fn test_duration() {
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 10,
-                            months: 20,
-                            days: 30,
-                            hours: 10,
-                            minutes: 20,
-                            seconds: 30,
-                        }),
-                   duration(b"PY10M20D30TH10M20S30"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 10,
+                    months: 20,
+                    days: 30,
+                    hours: 10,
+                    minutes: 20,
+                    seconds: 30,
+                }
+            ),
+            duration(b"P10Y20M30DT10H20M30S")
+        );
 
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 10,
-                            months: 0,
-                            days: 0,
-                            hours: 10,
-                            minutes: 0,
-                            seconds: 0,
-                        }),
-                   duration(b"PY10TH10S0"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 10,
+                    months: 0,
+                    days: 0,
+                    hours: 10,
+                    minutes: 0,
+                    seconds: 0,
+                }
+            ),
+            duration(b"P10YT10H0S")
+        );
 
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 0,
-                            months: 0,
-                            days: 0,
-                            hours: 0,
-                            minutes: 1000,
-                            seconds: 0,
-                        }),
-                   duration(b"PTM1000S0"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 0,
+                    months: 0,
+                    days: 0,
+                    hours: 0,
+                    minutes: 1000,
+                    seconds: 0,
+                }
+            ),
+            duration(b"PT1000M0S")
+        );
 
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 10,
-                            months: 0,
-                            days: 0,
-                            hours: 0,
-                            minutes: 0,
-                            seconds: 0,
-                        }),
-                   duration(b"PY10TS0"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 10,
+                    months: 0,
+                    days: 0,
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                }
+            ),
+            duration(b"P10YT0S")
+        );
 
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 0,
-                            months: 10,
-                            days: 0,
-                            hours: 0,
-                            minutes: 0,
-                            seconds: 0,
-                        }),
-                   duration(b"PM10TS0"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 0,
+                    months: 10,
+                    days: 0,
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                }
+            ),
+            duration(b"P10MT0S")
+        );
 
-        assert_eq!(Done(&[][..],
-                        Duration {
-                            years: 0,
-                            months: 0,
-                            days: 0,
-                            hours: 0,
-                            minutes: 10,
-                            seconds: 0,
-                        }),
-                   duration(b"PTM10S0"));
+        assert_eq!(
+            Done(
+                &[][..],
+                Duration {
+                    years: 0,
+                    months: 0,
+                    days: 0,
+                    hours: 0,
+                    minutes: 10,
+                    seconds: 0,
+                }
+            ),
+            duration(b"PT10M0S")
+        );
 
-        assert!(duration(b"YTM1000").is_err());
+        assert!(duration(b"YT1000M").is_err());
     }
-
 }

--- a/src/parsers/duration.rs
+++ b/src/parsers/duration.rs
@@ -6,13 +6,13 @@ use std::str;
 use std::str::FromStr;
 
 named!(u32_digit<u32>,
+  map_res!(
     map_res!(
-        map_res!(
-            digit, 
-            str::from_utf8
-        ), 
-        FromStr::from_str
-    )
+      digit,
+      str::from_utf8
+    ),
+    FromStr::from_str
+  )
 );
 
 // parse duration
@@ -39,7 +39,7 @@ named!(pub duration <Duration>, chain!(
 ));
 
 // parse duration time
-named!(duration_time<(u32, u32, u32)>, dbg!(chain!(
+named!(duration_time <(u32, u32, u32)>, dbg!(chain!(
     complete!(tag!("T")) ~
     h: terminated!(u32_digit, tag!("H"))? ~
     m: terminated!(u32_digit, tag!("M"))? ~

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -61,83 +61,83 @@ fn test_duration() {
 #[test]
 fn test_closed() {
     assert_eq!(parse("+1000/+2000-10-01").unwrap().get_range().unwrap(),
-        Range {
-            start: Some(DateTime {
-                date: Date {
-                    year: 1000,
-                    month: None,
-                    day: None,
-                },
-                time: None,
-            }),
-            end: Some(DateTimeOrDuration::DateTime(DateTime {
-                date: Date {
-                    year: 2000,
-                    month: Some(10),
-                    day: Some(1),
-                },
-                time: None,
-            })),
-            approximate: false,
-        });
+               Range {
+                   start: Some(DateTime {
+                       date: Date {
+                           year: 1000,
+                           month: None,
+                           day: None,
+                       },
+                       time: None,
+                   }),
+                   end: Some(DateTimeOrDuration::DateTime(DateTime {
+                       date: Date {
+                           year: 2000,
+                           month: Some(10),
+                           day: Some(1),
+                       },
+                       time: None,
+                   })),
+                   approximate: false,
+               });
 }
 
 #[test]
 fn test_open_start() {
     assert_eq!(parse("/+2000-10-01").unwrap().get_range().unwrap(),
-        Range {
-            start: None,
-            end: Some(DateTimeOrDuration::DateTime(DateTime {
-                date: Date {
-                    year: 2000,
-                    month: Some(10),
-                    day: Some(1),
-                },
-                time: None,
-            })),
-            approximate: false,
-        });
+               Range {
+                   start: None,
+                   end: Some(DateTimeOrDuration::DateTime(DateTime {
+                       date: Date {
+                           year: 2000,
+                           month: Some(10),
+                           day: Some(1),
+                       },
+                       time: None,
+                   })),
+                   approximate: false,
+               });
 }
 
 #[test]
 fn test_open_end() {
     assert_eq!(parse("+1000/").unwrap().get_range().unwrap(),
-        Range {
-            start: Some(DateTime {
-                date: Date {
-                    year: 1000,
-                    month: None,
-                    day: None,
-                },
-                time: None,
-            }),
-            end: None,
-            approximate: false,
-        });
+               Range {
+                   start: Some(DateTime {
+                       date: Date {
+                           year: 1000,
+                           month: None,
+                           day: None,
+                       },
+                       time: None,
+                   }),
+                   end: None,
+                   approximate: false,
+               });
 }
 
 #[test]
 fn test_approximate() {
     assert_eq!(parse("A+1000/+2000-10-01").unwrap().get_range().unwrap(),
-        Range {
-            start: Some(DateTime {
-                date: Date {
-                    year: 1000,
-                    month: None,
-                    day: None,
-                },
-                time: None,
-            }),
-            end: Some(DateTimeOrDuration::DateTime(DateTime {
-                date: Date {
-                    year: 2000,
-                    month: Some(10),
-                    day: Some(1),
-                },
-                time: None,
-            })),
-            approximate: true,
-        });
+               Range {
+                   start: Some(DateTime {
+                       date: Date {
+                           year: 1000,
+                           month: None,
+                           day: None,
+                       },
+                       time: None,
+                   }),
+                   end: Some(DateTimeOrDuration::DateTime(DateTime {
+                       date: Date {
+                           year: 2000,
+                           month: Some(10),
+                           day: Some(1),
+                       },
+                       time: None,
+                   })),
+                   approximate: true,
+               });
 }
 
 #[test]

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -36,108 +36,108 @@ fn test_invalid_part2() {
 
 #[test]
 fn test_duration() {
-    assert_eq!(parse("+1000/PY1M2D3TH4M5S6").unwrap().get_range().unwrap(),
-               Range {
-                   start: Some(DateTime {
-                       date: Date {
-                           year: 1000,
-                           month: None,
-                           day: None,
-                       },
-                       time: None,
-                   }),
-                   end: Some(DateTimeOrDuration::Duration(Duration {
-                       years: 1,
-                       months: 2,
-                       days: 3,
-                       hours: 4,
-                       minutes: 5,
-                       seconds: 6,
-                   })),
-                   approximate: false,
-               });
+    assert_eq!(parse("+1000/P1Y2M3DT4H5M6S").unwrap().get_range().unwrap(),
+        Range {
+            start: Some(DateTime {
+                date: Date {
+                    year: 1000,
+                    month: None,
+                    day: None,
+                },
+                time: None,
+            }),
+            end: Some(DateTimeOrDuration::Duration(Duration {
+                years: 1,
+                months: 2,
+                days: 3,
+                hours: 4,
+                minutes: 5,
+                seconds: 6,
+            })),
+            approximate: false,
+        });
 }
 
 #[test]
 fn test_closed() {
     assert_eq!(parse("+1000/+2000-10-01").unwrap().get_range().unwrap(),
-               Range {
-                   start: Some(DateTime {
-                       date: Date {
-                           year: 1000,
-                           month: None,
-                           day: None,
-                       },
-                       time: None,
-                   }),
-                   end: Some(DateTimeOrDuration::DateTime(DateTime {
-                       date: Date {
-                           year: 2000,
-                           month: Some(10),
-                           day: Some(1),
-                       },
-                       time: None,
-                   })),
-                   approximate: false,
-               });
+        Range {
+            start: Some(DateTime {
+                date: Date {
+                    year: 1000,
+                    month: None,
+                    day: None,
+                },
+                time: None,
+            }),
+            end: Some(DateTimeOrDuration::DateTime(DateTime {
+                date: Date {
+                    year: 2000,
+                    month: Some(10),
+                    day: Some(1),
+                },
+                time: None,
+            })),
+            approximate: false,
+        });
 }
 
 #[test]
 fn test_open_start() {
     assert_eq!(parse("/+2000-10-01").unwrap().get_range().unwrap(),
-               Range {
-                   start: None,
-                   end: Some(DateTimeOrDuration::DateTime(DateTime {
-                       date: Date {
-                           year: 2000,
-                           month: Some(10),
-                           day: Some(1),
-                       },
-                       time: None,
-                   })),
-                   approximate: false,
-               });
+        Range {
+            start: None,
+            end: Some(DateTimeOrDuration::DateTime(DateTime {
+                date: Date {
+                    year: 2000,
+                    month: Some(10),
+                    day: Some(1),
+                },
+                time: None,
+            })),
+            approximate: false,
+        });
 }
 
 #[test]
 fn test_open_end() {
     assert_eq!(parse("+1000/").unwrap().get_range().unwrap(),
-               Range {
-                   start: Some(DateTime {
-                       date: Date {
-                           year: 1000,
-                           month: None,
-                           day: None,
-                       },
-                       time: None,
-                   }),
-                   end: None,
-                   approximate: false,
-               });
+        Range {
+            start: Some(DateTime {
+                date: Date {
+                    year: 1000,
+                    month: None,
+                    day: None,
+                },
+                time: None,
+            }),
+            end: None,
+            approximate: false,
+        });
 }
 
 #[test]
 fn test_approximate() {
     assert_eq!(parse("A+1000/+2000-10-01").unwrap().get_range().unwrap(),
-               Range {
-                   start: Some(DateTime {
-                       date: Date {
-                           year: 1000,
-                           month: None,
-                           day: None,
-                       },
-                       time: None,
-                   }),
-                   end: Some(DateTimeOrDuration::DateTime(DateTime {
-                       date: Date {
-                           year: 2000,
-                           month: Some(10),
-                           day: Some(1),
-                       },
-                       time: None,
-                   })),
-                   approximate: true,
-               });
+        Range {
+            start: Some(DateTime {
+                date: Date {
+                    year: 1000,
+                    month: None,
+                    day: None,
+                },
+                time: None,
+            }),
+            end: Some(DateTimeOrDuration::DateTime(DateTime {
+                date: Date {
+                    year: 2000,
+                    month: Some(10),
+                    day: Some(1),
+                },
+                time: None,
+            })),
+            approximate: true,
+        });
 }
 
 #[test]

--- a/tests/recurring.rs
+++ b/tests/recurring.rs
@@ -86,7 +86,7 @@ fn test_count() {
 
 #[test]
 fn test_duration() {
-    assert_eq!(parse("R/+1000/PY1M2D3TH4M5S6").unwrap().get_recurring().unwrap(),
+    assert_eq!(parse("R/+1000/P1Y2M3DT4H5M6S").unwrap().get_recurring().unwrap(),
                Recurring {
                    start: DateTime {
                        date: Date {


### PR DESCRIPTION
Hi, 
I'm working on a Gedcomx parsing crate (https://github.com/ephraimkunz/gedcomx-rs) and was planning on using this crate for the Gedcomx date implementation. 

While reading the date spec, I came across some examples of the "duration" format (https://github.com/FamilySearch/gedcomx/blob/master/specifications/date-format-specification.md#533-examples).

It appears this crate doesn't correctly parse durations. The current parsing code tries to parse a string like this:
`PY1M2D3TH4M5S6`

However, according to my reading of the spec that's not a valid duration string. Instead it should be:
`P1Y2M3DT4H5M6S`.

In other words, the length of the duration component should come before the specifier for which component it is, not after. 
